### PR TITLE
Reset Members to array instead of string

### DIFF
--- a/XML/RSS.php
+++ b/XML/RSS.php
@@ -261,17 +261,17 @@ class XML_RSS extends XML_Parser
 
         if ($element == 'ITEM') {
             $this->items[] = $this->item;
-            $this->item = '';
+            $this->item = array();
         }
 
         if ($element == 'IMAGE') {
             $this->images[] = $this->image;
-            $this->image = '';
+            $this->image = array();
         }
 
         if ($element == 'TEXTINPUT') {
             $this->textinputs = $this->textinput;
-            $this->textinput = '';
+            $this->textinput = array();
         }
 
         if ($element == 'ENCLOSURE') {


### PR DESCRIPTION
Fixes https://pear.php.net/bugs/bug.php?id=21168 ( Cannot use string offset as an array ), which is raised in PHP7.1 when using XML_RSS with feeds such as:

http://www.n-tv.de/23.rss 
http://www.handelsblatt.com/contentexport/feed/schlagzeilen 
http://www.spiegel.de/politik/index.rss